### PR TITLE
Mark updates as confirmed using offset + 1 as described in Bot API

### DIFF
--- a/lib/telebot/bot.rb
+++ b/lib/telebot/bot.rb
@@ -13,7 +13,10 @@ module Telebot
 
     def run(&block)
       loop do
-        updates = @client.get_updates(offset: @processed_update_ids.last)
+        # Note: https://core.telegram.org/bots/api#getupdates
+        # To mark an update as confirmed need to use offset+1
+        offset = @processed_update_ids.last && @processed_update_ids.last + 1
+        updates = @client.get_updates(offset: offset)
 
         updates.each do |update|
           next if @processed_update_ids.include?(update.update_id)


### PR DESCRIPTION
Each time my bot restarted it always got the last message again. The Bot API can mark updates as confirmed, in which case they will not be redelivered but only when they are strictly less than the offset.

I made the change recommended in the Api Docs and pass last_update + 1 as the offset.
