### PR TITLE
faraday_middleware removed

### DIFF
--- a/lib/telebot.rb
+++ b/lib/telebot.rb
@@ -1,6 +1,5 @@
 require 'virtus'
 require 'faraday'
-require 'faraday_middleware'
 
 require "telebot/objects/user"
 require "telebot/objects/group_chat"

--- a/telebot.gemspec
+++ b/telebot.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday"
-  spec.add_dependency "faraday_middleware"
   spec.add_dependency "virtus"
 
   spec.add_development_dependency "bundler", "~> 1.1"


### PR DESCRIPTION
It looks like this dependency is not necessary. That's why, removing it.